### PR TITLE
Fix documentation

### DIFF
--- a/ctaplot/ana/ana.py
+++ b/ctaplot/ana/ana.py
@@ -42,7 +42,6 @@ __all__ = ['irf_cta',
            'bias_per_bin',
            'percentile_confidence_interval',
            'logbin_mean',
-           'binned_statistic'
            ]
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Welcome to ctaplot's documentation!
 Contents
 --------
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    README
    license

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -2,20 +2,28 @@ Modules
 =======
 
 
-.. automodule:: ctaplot.plots
+.. automodule:: ctaplot.plots.plots
     :members:
     :undoc-members:
     :show-inheritance:
 
-
-
-.. automodule:: ctaplot.ana
+.. automodule:: ctaplot.plots.calib
     :members:
     :undoc-members:
     :show-inheritance:
 
-
-.. automodule:: ctaplot.gammaboard
+.. automodule:: ctaplot.ana.ana
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. automodule:: ctaplot.io.io
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: ctaplot.io.dataset
+    :members:
+    :undoc-members:
+    :show-inheritance:
+


### PR DESCRIPTION
- Documentation modules were not displayed, now fixed
- remove `scipy.stats.binned_statistic` from `ctaplot.ana` 